### PR TITLE
fix: replace tooltip with always-visible subtitles

### DIFF
--- a/entrypoints/popup/popup.tsx
+++ b/entrypoints/popup/popup.tsx
@@ -188,24 +188,23 @@ export default function Popup() {
                       {features.map(f => {
                         const on = settings[f.key] as boolean;
                         return (
-                          <label
-                            key={f.key}
-                            className="toggle-row"
-                            title={f.description}
-                          >
-                            <span className="toggle-label">
-                              {f.label.replace('Hide ', '').replace('Disable ', '')}
-                            </span>
+                          <div key={f.key} className="toggle-row">
+                            <div className="toggle-text">
+                              <span className="toggle-label">
+                                {f.label.replace('Hide ', '').replace('Disable ', '')}
+                              </span>
+                              <span className="toggle-desc">{f.description}</span>
+                            </div>
                             <button
                               className={`switch ${on ? 'on' : 'off'}`}
                               onClick={(e) => { e.preventDefault(); handleToggle(f.key); }}
                               role="switch"
                               aria-checked={on}
-                              aria-label={f.description}
+                              aria-label={f.label}
                             >
                               <span className="switch-thumb" />
                             </button>
-                          </label>
+                          </div>
                         );
                       })}
                     </div>

--- a/entrypoints/styles/popup.css
+++ b/entrypoints/styles/popup.css
@@ -275,55 +275,41 @@ body {
   to { opacity: 1; transform: translateY(0); }
 }
 
-/* ── Toggle Row with tooltip ── */
+/* ── Toggle Row ── */
 .toggle-row {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 7px 10px;
+  gap: 12px;
+  padding: 8px 10px;
   border-radius: var(--radius-xs);
   cursor: pointer;
   transition: background var(--transition);
-  position: relative;
 }
 
 .toggle-row:hover {
   background: var(--bg-hover);
 }
 
-/* Native tooltip via title attribute, plus CSS custom tooltip */
-.toggle-row:hover::after {
-  content: attr(title);
-  position: absolute;
-  left: 10px;
-  bottom: calc(100% + 4px);
-  padding: 5px 10px;
-  background: #333;
-  color: #ddd;
-  font-size: 10px;
-  border-radius: var(--radius-xs);
-  white-space: nowrap;
-  z-index: 50;
-  pointer-events: none;
-  animation: tooltipIn 0.15s ease;
-  box-shadow: 0 4px 12px rgba(0,0,0,0.4);
-  max-width: 260px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-/* Hide native tooltip to avoid double */
-.toggle-row[title] { cursor: pointer; }
-
-@keyframes tooltipIn {
-  from { opacity: 0; transform: translateY(2px); }
-  to { opacity: 1; transform: translateY(0); }
+.toggle-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  flex: 1;
+  min-width: 0;
 }
 
 .toggle-label {
   font-size: 12px;
   color: var(--text-secondary);
-  font-weight: 400;
+  font-weight: 500;
+}
+
+.toggle-desc {
+  font-size: 10px;
+  color: var(--text-muted);
+  line-height: 1.35;
+  opacity: 0.7;
 }
 
 /* ── Toggle Switch ── */


### PR DESCRIPTION
## Summary
- Removed click-to-expand ⓘ info button (required 2 clicks — bad UX)
- Removed hover tooltip system (overlapped other toggles)
- Added always-visible subtitle descriptions below each toggle label
- Zero friction — users instantly understand every feature at a glance

## Before → After
**Before:** Hover/click caused large tooltip that covered adjacent toggles
**After:** Subtle muted description text always visible (iOS Settings pattern)

## Test plan
- [ ] Load extension in chrome://extensions
- [ ] Open popup — each toggle should show label + subtitle
- [ ] No hover/click interaction needed to see descriptions
- [ ] Scrolling through all categories should be clean with no overlap

🤖 Generated with [Claude Code](https://claude.com/claude-code)