### PR TITLE
feat: v1.2.0 — Support modal & Bug Report form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to D-Tox will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] - 2026-03-31
+
+### Added
+- **Support modal** — replaces bare UPI link with a polished slide-up modal containing two clear sections:
+  - *Share* — prompts users to share the extension with friends/family as the primary form of support
+  - *Financial* — PayPal (clickable, opens in new tab) and UPI ID (`yesnajmush@ybl`) displayed inline with a one-click copy button
+- **Bug Report Google Form** — accessible to all users regardless of technical ability; replaces direct GitHub Issues link. Form includes browser, page context, frequency, and optional screenshot link fields. GitHub Issues link added at the bottom of the form itself for developers.
+- UPI hint text ("GPay · PhonePe · Paytm · any UPI app") shown inline — no tooltip friction
+
+### Changed
+- "Donate" renamed to "Support" throughout (footer + More tab) with 🤝 icon to avoid conflict with ❤️ in "Made with love" sign-off
+- Support footer button no longer links directly to UPI — opens modal instead
+
+### Fixed
+- Removed broken hover tooltip on UPI hint that was obscuring the UPI ID and rendering outside the modal bounds
+
+---
+
+All notable changes to D-Tox will be documented in this file.
+
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
 ## [1.1.1] - 2026-03-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -110,9 +110,9 @@ Contributions welcome! Fork, create a branch, make your changes, and submit a PR
 
 ## Support
 
-- **Donate**: [PayPal](http://paypal.me/hanjinajmush) or UPI `yesnajmush@ybl` (in-extension popup coming soon)
+- **Support the project**: Click 🤝 Support in the extension popup — share it, or contribute financially via PayPal / UPI
 - **Feature Request**: [Submit here](https://forms.gle/B1eb14KJGTRoiS179)
-- **Bug Report**: [GitHub Issues](https://github.com/najmushsaaquib/d-tox/issues)
+- **Bug Report**: [Submit here](https://forms.gle/dLTobfdskRPJ6poY6)
 
 ## License
 

--- a/entrypoints/popup/popup.tsx
+++ b/entrypoints/popup/popup.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useCallback } from 'react';
+import React, { useEffect, useState, useCallback, useRef } from 'react';
 import { Settings, FEATURE_METADATA, CATEGORY_INFO } from '../../src/utils/types';
 import {
   loadSettings, saveSettings, loadCurrentPreset,
@@ -9,17 +9,114 @@ import { PRESETS } from '../../src/utils/presets';
 
 type Tab = 'toggles' | 'presets' | 'more';
 
-const DONATE_UPI      = 'upi://pay?pa=yesnajmush@ybl&pn=Najmush&cu=INR';
-const FEATURE_FORM    = 'https://forms.gle/B1eb14KJGTRoiS179';
-const GITHUB_URL      = 'https://github.com/najmushsaaquib/d-tox';
-const GITHUB_PROFILE  = 'https://github.com/najmushsaaquib';
+const UPI_ID         = 'yesnajmush@ybl';
+const PAYPAL_URL     = 'https://paypal.me/hanjinajmush';
+const FEATURE_FORM   = 'https://forms.gle/B1eb14KJGTRoiS179';
+const BUG_FORM       = 'https://forms.gle/dLTobfdskRPJ6poY6';
+const GITHUB_URL     = 'https://github.com/najmushsaaquib/d-tox';
+const GITHUB_PROFILE = 'https://github.com/najmushsaaquib';
 
+// ── Support Modal ─────────────────────────────────────────────────────────────
+function SupportModal({ onClose, showToast }: { onClose: () => void; showToast: (msg: string) => void }) {
+  const backdropRef = useRef<HTMLDivElement>(null);
+
+  // Close on ESC
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [onClose]);
+
+  const copyUPI = async () => {
+    await navigator.clipboard.writeText(UPI_ID);
+    showToast('UPI ID copied');
+  };
+
+  return (
+    <div
+      className="modal-backdrop"
+      ref={backdropRef}
+      onClick={e => { if (e.target === backdropRef.current) onClose(); }}
+    >
+      <div className="modal" role="dialog" aria-modal="true" aria-label="Support D-Tox">
+
+        {/* Header */}
+        <div className="modal-header">
+          <span className="modal-title">Support D-Tox</span>
+          <button className="modal-close" onClick={onClose} aria-label="Close">×</button>
+        </div>
+
+        {/* Section 1 — Share */}
+        <div className="modal-section">
+          <p className="modal-lead">
+            The best way to support D-Tox is to <strong>share it</strong> — with a friend, a colleague, anyone
+            who deserves a cleaner YouTube. Help them reclaim their attention too.
+          </p>
+          <a
+            className="modal-share-btn"
+            href={GITHUB_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Share the extension →
+          </a>
+        </div>
+
+        <div className="modal-divider" />
+
+        {/* Section 2 — Financial */}
+        <div className="modal-section">
+          <p className="modal-sublabel">Want to support financially? No pressure — but it means a lot.</p>
+
+          {/* PayPal */}
+          <a
+            className="modal-pay-row"
+            href={PAYPAL_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <span className="modal-pay-logo">
+              {/* PayPal wordmark SVG */}
+              <svg viewBox="0 0 80 20" fill="none" xmlns="http://www.w3.org/2000/svg" aria-label="PayPal">
+                <text x="0" y="16" fontFamily="-apple-system,sans-serif" fontSize="15" fontWeight="700" fill="#003087">Pay</text>
+                <text x="28" y="16" fontFamily="-apple-system,sans-serif" fontSize="15" fontWeight="700" fill="#009cde">Pal</text>
+              </svg>
+            </span>
+            <span className="modal-pay-text">Pay via PayPal</span>
+            <span className="modal-pay-arrow">↗</span>
+          </a>
+
+          {/* UPI */}
+          <div className="modal-pay-row modal-upi-row">
+            <span className="modal-pay-logo">
+              {/* UPI wordmark */}
+              <svg viewBox="0 0 44 20" fill="none" xmlns="http://www.w3.org/2000/svg" aria-label="UPI">
+                <text x="0" y="15" fontFamily="-apple-system,sans-serif" fontSize="13" fontWeight="800" fill="#097939">U</text>
+                <text x="11" y="15" fontFamily="-apple-system,sans-serif" fontSize="13" fontWeight="800" fill="#FF6B35">P</text>
+                <text x="22" y="15" fontFamily="-apple-system,sans-serif" fontSize="13" fontWeight="800" fill="#097939">I</text>
+              </svg>
+            </span>
+            <div className="modal-upi-body">
+              <span className="modal-upi-id">{UPI_ID}</span>
+              <span className="modal-upi-hint">GPay · PhonePe · Paytm · any UPI app</span>
+            </div>
+            <button className="modal-copy-btn" onClick={copyUPI}>Copy</button>
+          </div>
+        </div>
+
+      </div>
+    </div>
+  );
+}
+
+// ── Popup ─────────────────────────────────────────────────────────────────────
 export default function Popup() {
-  const [settings, setSettings] = useState<Settings | null>(null);
+  const [settings, setSettings]         = useState<Settings | null>(null);
   const [currentPreset, setCurrentPreset] = useState<string | null>(null);
-  const [activeTab, setActiveTab] = useState<Tab>('toggles');
+  const [activeTab, setActiveTab]       = useState<Tab>('toggles');
   const [expandedCats, setExpandedCats] = useState<Set<string>>(new Set(['feed']));
-  const [toast, setToast] = useState<string | null>(null);
+  const [toast, setToast]               = useState<string | null>(null);
+  const [showSupport, setShowSupport]   = useState(false);
 
   useEffect(() => {
     (async () => {
@@ -119,13 +216,12 @@ export default function Popup() {
     grouped[f.category].push(f);
   });
 
-  const countActive = (cat: string) => {
-    const features = grouped[cat] || [];
-    return features.filter(f => settings[f.key] as boolean).length;
-  };
+  const countActive = (cat: string) =>
+    (grouped[cat] || []).filter(f => settings[f.key] as boolean).length;
 
   return (
     <div className={`popup ${!settings.extensionEnabled ? 'disabled' : ''}`}>
+
       {/* Header */}
       <header className="header">
         <div className="header-left">
@@ -135,9 +231,7 @@ export default function Popup() {
                 <path d="M36,26 L36,102 C36,104 38,105 41,103 L102,69 C105,67 105,61 102,59 L41,25 C38,23 36,24 36,26 Z"/>
               </clipPath>
               <g clipPath="url(#logo-clip)">
-                {/* Body: red when active, blue when paused */}
                 <rect x="0" y="0" width="128" height="128" fill={settings.extensionEnabled ? '#e53e3e' : '#60a5fa'}/>
-                {/* Tip: blue when active, red when paused — exact swap */}
                 <circle cx="102" cy="64" r="26" fill={settings.extensionEnabled ? '#60a5fa' : '#e53e3e'}/>
               </g>
             </svg>
@@ -150,9 +244,7 @@ export default function Popup() {
           onClick={handleMasterToggle}
           title={settings.extensionEnabled ? 'Pause D-Tox' : 'Enable D-Tox'}
         >
-          <span className="master-track">
-            <span className="master-thumb" />
-          </span>
+          <span className="master-track"><span className="master-thumb" /></span>
         </button>
       </header>
 
@@ -166,7 +258,7 @@ export default function Popup() {
           >
             {tab === 'toggles' && 'Toggles'}
             {tab === 'presets' && 'Presets'}
-            {tab === 'more' && 'More'}
+            {tab === 'more'    && 'More'}
           </button>
         ))}
       </nav>
@@ -178,8 +270,8 @@ export default function Popup() {
         {activeTab === 'toggles' && (
           <div className="toggles-tab">
             {Object.entries(grouped).map(([cat, features]) => {
-              const info = CATEGORY_INFO[cat];
-              const active = countActive(cat);
+              const info     = CATEGORY_INFO[cat];
+              const active   = countActive(cat);
               const expanded = expandedCats.has(cat);
               return (
                 <div key={cat} className="category">
@@ -205,7 +297,7 @@ export default function Popup() {
                             </div>
                             <button
                               className={`switch ${on ? 'on' : 'off'}`}
-                              onClick={(e) => { e.preventDefault(); handleToggle(f.key); }}
+                              onClick={e => { e.preventDefault(); handleToggle(f.key); }}
                               role="switch"
                               aria-checked={on}
                               aria-label={f.label}
@@ -261,13 +353,13 @@ export default function Popup() {
             <div className="more-divider" />
             <div className="more-section">
               <h3 className="more-heading">Support</h3>
-              <a className="more-btn" href={DONATE_UPI}>
-                <span>💸</span> Donate via UPI
-              </a>
+              <button className="more-btn" onClick={() => setShowSupport(true)}>
+                <span>🤝</span> Support D-Tox
+              </button>
               <a className="more-btn" href={FEATURE_FORM} target="_blank" rel="noopener noreferrer">
                 <span>💡</span> Request a Feature
               </a>
-              <a className="more-btn" href={GITHUB_URL + '/issues'} target="_blank" rel="noopener noreferrer">
+              <a className="more-btn" href={BUG_FORM} target="_blank" rel="noopener noreferrer">
                 <span>🐛</span> Report a Bug
               </a>
               <a className="more-btn" href={GITHUB_URL} target="_blank" rel="noopener noreferrer">
@@ -280,12 +372,17 @@ export default function Popup() {
 
       {/* Footer */}
       <footer className="footer">
-        <a href={DONATE_UPI}>💸 Donate</a>
+        <button className="footer-btn" onClick={() => setShowSupport(true)}>🤝 Support</button>
         <span className="footer-dot">·</span>
         <a href={FEATURE_FORM} target="_blank" rel="noopener noreferrer">💡 Request Feature</a>
         <span className="footer-dot">·</span>
         <span className="footer-love">Made with ❤️ by <a href={GITHUB_PROFILE} target="_blank" rel="noopener noreferrer" className="author-link">Najmush</a></span>
       </footer>
+
+      {/* Support Modal */}
+      {showSupport && (
+        <SupportModal onClose={() => setShowSupport(false)} showToast={showToast} />
+      )}
 
       {/* Toast */}
       {toast && <div className="toast">{toast}</div>}

--- a/entrypoints/styles/popup.css
+++ b/entrypoints/styles/popup.css
@@ -487,6 +487,192 @@ body {
   border-color: rgba(255,255,255,0.4);
 }
 
+/* ── Footer button (Support) ── */
+.footer-btn {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  font-size: 12px;
+  font-weight: 500;
+  font-family: inherit;
+  cursor: pointer;
+  padding: 0;
+  transition: color var(--transition);
+}
+.footer-btn:hover { color: var(--text-primary); }
+
+/* ── Support Modal ── */
+.modal-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.65);
+  backdrop-filter: blur(2px);
+  display: flex;
+  align-items: flex-end;
+  z-index: 200;
+  animation: backdropIn 0.18s ease;
+}
+
+@keyframes backdropIn {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+.modal {
+  width: 100%;
+  background: #181818;
+  border-top: 1px solid var(--border-light);
+  border-radius: 16px 16px 0 0;
+  padding: 0 0 8px;
+  animation: modalUp 0.22s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+}
+
+@keyframes modalUp {
+  from { transform: translateY(20px); opacity: 0; }
+  to   { transform: translateY(0);    opacity: 1; }
+}
+
+.modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 16px 10px;
+  border-bottom: 1px solid var(--border);
+}
+
+.modal-title {
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--text-primary);
+  letter-spacing: 0.1px;
+}
+
+.modal-close {
+  width: 24px; height: 24px;
+  border-radius: 50%;
+  border: none;
+  background: var(--bg-tertiary);
+  color: var(--text-muted);
+  font-size: 16px;
+  line-height: 1;
+  cursor: pointer;
+  display: flex; align-items: center; justify-content: center;
+  transition: all var(--transition);
+}
+.modal-close:hover { background: var(--bg-hover); color: var(--text-primary); }
+
+.modal-section { padding: 14px 16px; }
+
+.modal-lead {
+  font-size: 12.5px;
+  color: rgba(255,255,255,0.55);
+  line-height: 1.65;
+  margin-bottom: 12px;
+}
+.modal-lead strong { color: var(--text-primary); font-weight: 600; }
+
+.modal-share-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 16px;
+  background: var(--accent);
+  color: #fff;
+  font-size: 12px;
+  font-weight: 600;
+  border-radius: 999px;
+  text-decoration: none;
+  transition: background var(--transition), transform var(--transition);
+}
+.modal-share-btn:hover { background: #cc3333; transform: translateY(-1px); }
+
+.modal-divider {
+  height: 1px;
+  background: var(--border);
+  margin: 0 16px;
+}
+
+.modal-sublabel {
+  font-size: 11px;
+  color: var(--text-muted);
+  margin-bottom: 10px;
+  line-height: 1.5;
+}
+
+/* Payment rows */
+.modal-pay-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 12px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  text-decoration: none;
+  color: var(--text-secondary);
+  font-size: 12.5px;
+  transition: all var(--transition);
+  margin-bottom: 8px;
+}
+.modal-pay-row:hover {
+  background: var(--bg-hover);
+  border-color: var(--border-light);
+  color: var(--text-primary);
+}
+
+.modal-pay-logo {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+  width: 44px;
+}
+.modal-pay-logo svg { width: 100%; height: auto; }
+
+.modal-pay-text { flex: 1; font-weight: 500; }
+.modal-pay-arrow { color: var(--text-muted); font-size: 13px; }
+
+/* UPI row — not a link, no hover redirect */
+.modal-upi-row {
+  cursor: default;
+  margin-bottom: 0;
+}
+.modal-upi-row:hover { background: var(--bg-secondary); border-color: var(--border); color: var(--text-secondary); }
+
+.modal-upi-body {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.modal-upi-id {
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--text-primary);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.3px;
+}
+
+.modal-upi-hint {
+  font-size: 10.5px;
+  color: var(--text-muted);
+}
+
+.modal-copy-btn {
+  padding: 5px 12px;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-light);
+  border-radius: 6px;
+  color: var(--text-secondary);
+  font-size: 11px;
+  font-weight: 600;
+  font-family: inherit;
+  cursor: pointer;
+  transition: all var(--transition);
+  flex-shrink: 0;
+}
+.modal-copy-btn:hover { background: var(--bg-hover); color: var(--text-primary); }
+
 /* ── Toast ── */
 .toast {
   position: fixed;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d-tox",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Detox your YouTube. Hide distractions, disable autoplay, and reclaim your attention.",
   "author": "Your Name",
   "license": "MIT",

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   outDir: 'dist',
   manifest: {
     name: 'D-Tox: YouTube Detox',
-    version: '1.1.0',
+    version: '1.2.0',
     description: 'Detox your YouTube. Hide distractions, disable autoplay, and reclaim your attention.',
     permissions: [
       'storage',


### PR DESCRIPTION
## Summary
- **Support modal** — slide-up modal with two sections: share the extension (primary ask) + financial support via PayPal and UPI with inline copy button
- **Bug Report** now opens a Google Form accessible to all users (no GitHub account needed); GitHub Issues link is surfaced inside the form itself for developers
- Renamed Donate → Support (🤝) throughout to avoid icon conflict with ❤️ sign-off
- Removed broken UPI tooltip that was obscuring the UPI ID; replaced with clean inline hint text
- Version bumped to 1.2.0, CHANGELOG and README updated

## Test plan
- [ ] Click 🤝 Support in footer → modal slides up
- [ ] Backdrop click and ESC both close modal
- [ ] PayPal row opens paypal.me/hanjinajmush in new tab
- [ ] Copy button on UPI ID copies `yesnajmush@ybl` and shows toast
- [ ] Report a Bug → opens Google Form in new tab
- [ ] Version reads v1.2.0 in popup header

🤖 Generated with [Claude Code](https://claude.com/claude-code)