### PR TITLE
fix: rebuild feature toggles for instant YouTube blocking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,38 @@ All notable changes to D-Tox will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.0] - 2026-03-31
+
+### Added
+- **Pure CSS Shorts blocking** — `ytd-video-renderer:has(a#thumbnail[href^="/shorts/"])` hides individual Shorts in search results instantly, no JS scanning needed
+- **New YouTube DOM support** — targets `grid-shelf-view-model`, `ytm-shorts-lockup-view-model`, `ytm-shorts-lockup-view-model-v2` (YouTube 2025+ elements)
+- **Shorts filter chip hiding** — the "Shorts" chip in search filter bar is now hidden via JS marker + CSS
+- **Instant toggle feedback** — popup sends `chrome.tabs.sendMessage()` directly to content script; no waiting for storage events
+- **Layout reflow guarantee** — `void document.body.offsetHeight` after every CSS update forces immediate visual changes
+- **YouTube SPA event listener** — uses native `yt-navigate-finish` event instead of heavy MutationObserver for page navigation detection
+- **Style tag watchdog** — monitors `<head>` for removal of D-Tox style tag and re-injects immediately
+- **Explore section JS marker** — marks guide sections containing Trending/Shopping/Gaming for reliable hiding
+
+### Fixed
+- **Shorts reload loop** — removed blanket `grid-shelf-view-model` and `[is-shorts]` selectors that hid all search content, causing infinite scroll cascade
+- **Sidebar not centering on toggle** — added `#primary { max-width: none !important }` to override YouTube's locked two-column width
+- **Header toggle leaving gap** — added `ytd-page-manager { margin-top: 0 !important }` to remove 56px placeholder
+- **Style tag removal loop** — `injectStyles` now updates `textContent` in-place instead of remove+recreate cycle
+- **Explore section not hiding** — replaced individual link targeting with whole `ytd-guide-section-renderer` targeting via `:has()` and JS marker
+
+### Changed
+- Shorts hiding moved from JS marker approach to pure CSS `:has()` selectors for zero-latency hiding
+- Navigation detection changed from `MutationObserver(body, subtree)` to `yt-navigate-finish` event + lightweight `setInterval(1000)` fallback
+- Element marker interval reduced from aggressive MutationObserver to calm `setInterval(2000)`
+- Annotations description updated to "Hides info cards, end screens and clickable overlay links that appear during videos"
+
+### Removed
+- Broken `[is-shorts]` blanket CSS selector
+- Heavy `MutationObserver` on `document.body` with `subtree: true`
+- JS-based Shorts marking for search results (replaced by pure CSS)
+
+---
+
 ## [1.2.0] - 2026-03-31
 
 ### Added
@@ -22,11 +54,6 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Removed broken hover tooltip on UPI hint that was obscuring the UPI ID and rendering outside the modal bounds
 
 ---
-
-All notable changes to D-Tox will be documented in this file.
-
-Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
-Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [1.1.1] - 2026-03-26
 

--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -3,6 +3,93 @@ import { loadSettings, onSettingsChange } from '../src/utils/storage';
 import { applyAllRules, cleanupStyles } from '../src/utils/css-injector';
 import type { Settings } from '../src/utils/types';
 
+// ─── Autoplay Observer ───────────────────────────────────────────────
+let autoplayObserver: MutationObserver | null = null;
+
+function disableAutoplayToggle() {
+  const btn = document.querySelector<HTMLElement>('.ytp-autonav-toggle-button');
+  if (btn && btn.getAttribute('aria-checked') === 'true') {
+    btn.click();
+  }
+}
+
+function startAutoplayObserver() {
+  disableAutoplayToggle();
+  if (autoplayObserver) return;
+  autoplayObserver = new MutationObserver(() => disableAutoplayToggle());
+  autoplayObserver.observe(document.documentElement, {
+    subtree: true,
+    attributes: true,
+    attributeFilter: ['aria-checked'],
+  });
+}
+
+function stopAutoplayObserver() {
+  autoplayObserver?.disconnect();
+  autoplayObserver = null;
+}
+
+// ─── Element Markers ────────────────────────────────────────────────
+// Marks elements that CSS alone cannot target (text-based matching).
+// Runs on a lightweight interval — no MutationObserver cascade.
+
+let markerInterval: ReturnType<typeof setInterval> | null = null;
+
+function markElements(settings: Settings) {
+  // Mark "Shorts" chip in search filter bar (CSS can't match by text)
+  if (settings.hideShorts) {
+    document.querySelectorAll('yt-chip-cloud-chip-renderer:not([dtox-checked])').forEach(chip => {
+      chip.setAttribute('dtox-checked', '');
+      const text = chip.textContent?.trim();
+      if (text === 'Shorts') {
+        chip.setAttribute('dtox-shorts-chip', '');
+      }
+    });
+  }
+
+  // Mark Explore guide section (CSS :has can be unreliable on dynamic sidebar)
+  if (settings.hideExplore) {
+    document.querySelectorAll('ytd-guide-section-renderer:not([dtox-checked])').forEach(section => {
+      section.setAttribute('dtox-checked', '');
+      const links = section.querySelectorAll('a');
+      for (const link of links) {
+        const title = link.getAttribute('title') || '';
+        const href = link.getAttribute('href') || '';
+        if (
+          title === 'Trending' || title === 'Shopping' || title === 'Gaming' ||
+          href.includes('/feed/trending') || href.includes('/feed/explore')
+        ) {
+          section.setAttribute('dtox-explore-section', '');
+          break;
+        }
+      }
+    });
+  }
+}
+
+function clearMarkers() {
+  document.querySelectorAll('[dtox-checked]').forEach(el => {
+    el.removeAttribute('dtox-checked');
+    el.removeAttribute('dtox-shorts-chip');
+    el.removeAttribute('dtox-explore-section');
+  });
+}
+
+function startMarkers(settings: Settings) {
+  markElements(settings);
+  if (!markerInterval) {
+    markerInterval = setInterval(() => markElements(settings), 2000);
+  }
+}
+
+function stopMarkers() {
+  if (markerInterval) {
+    clearInterval(markerInterval);
+    markerInterval = null;
+  }
+}
+
+// ─── Main Content Script ────────────────────────────────────────────
 export default defineContentScript({
   matches: ['https://*.youtube.com/*', 'https://youtube.com/*'],
   async main() {
@@ -11,9 +98,26 @@ export default defineContentScript({
     function apply(settings: Settings) {
       current = settings;
       if (settings.extensionEnabled) {
+        // Clear old markers so toggled-off features don't leave stale attrs
+        clearMarkers();
         applyAllRules(settings);
+        startMarkers(settings);
+
+        // Force synchronous layout reflow so CSS changes (like sidebar
+        // centering or header removal) apply visually without page reload.
+        void document.body.offsetHeight;
+
+        if (settings.disableAutoplay) {
+          startAutoplayObserver();
+        } else {
+          stopAutoplayObserver();
+        }
       } else {
         cleanupStyles();
+        stopAutoplayObserver();
+        stopMarkers();
+        clearMarkers();
+        void document.body.offsetHeight;
       }
     }
 
@@ -22,23 +126,48 @@ export default defineContentScript({
       const settings = await loadSettings();
       apply(settings);
     } catch (e) {
-      console.error('[YouTube Detox] Init error:', e);
+      console.error('[D-Tox] Init error:', e);
     }
 
-    // React to setting changes from popup
+    // React to setting changes from popup (via storage)
     onSettingsChange(apply);
 
-    // Re-apply on SPA navigation (YouTube is a SPA)
-    let lastUrl = location.href;
-    const observer = new MutationObserver(() => {
-      if (location.href !== lastUrl) {
-        lastUrl = location.href;
-        if (current?.extensionEnabled) {
-          setTimeout(() => apply(current!), 500);
-        }
+    // React to direct message from popup (faster than storage events)
+    chrome.runtime.onMessage.addListener((msg) => {
+      if (msg?.type === 'dtox-settings-changed' && msg.settings) {
+        apply(msg.settings);
       }
     });
 
-    observer.observe(document.body, { childList: true, subtree: true });
+    // Re-apply on YouTube SPA navigation using YouTube's own event
+    document.addEventListener('yt-navigate-finish', () => {
+      if (current?.extensionEnabled) {
+        apply(current);
+      }
+    });
+
+    // Fallback: also detect URL changes for edge cases
+    let lastUrl = location.href;
+    const navCheck = setInterval(() => {
+      if (location.href !== lastUrl) {
+        lastUrl = location.href;
+        if (current?.extensionEnabled) {
+          setTimeout(() => apply(current!), 300);
+        }
+      }
+    }, 1000);
+
+    // Style tag watchdog — re-inject only if YouTube actually removed it
+    const styleWatchdog = new MutationObserver((mutations) => {
+      const wasRemoved = mutations.some(m =>
+        Array.from(m.removedNodes).some(
+          n => (n as HTMLElement).id === 'd-tox-styles'
+        )
+      );
+      if (wasRemoved && current?.extensionEnabled) {
+        applyAllRules(current);
+      }
+    });
+    styleWatchdog.observe(document.head, { childList: true });
   }
 });

--- a/entrypoints/popup/popup.tsx
+++ b/entrypoints/popup/popup.tsx
@@ -137,11 +137,22 @@ export default function Popup() {
     setTimeout(() => setToast(null), 1500);
   }, []);
 
+  /** Notify the active YouTube tab immediately so changes apply without reload */
+  const notifyContentScript = async (next: Settings) => {
+    try {
+      const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+      if (tab?.id && tab.url?.includes('youtube.com')) {
+        chrome.tabs.sendMessage(tab.id, { type: 'dtox-settings-changed', settings: next });
+      }
+    } catch { /* tab may not have content script yet — storage listener is the fallback */ }
+  };
+
   const handleToggle = async (key: keyof Settings) => {
     if (!settings) return;
     const next = { ...settings, [key]: !settings[key] };
     setSettings(next);
     await saveSettings(next);
+    notifyContentScript(next);
     setCurrentPreset(null);
   };
 
@@ -150,6 +161,7 @@ export default function Popup() {
     const next = { ...settings, extensionEnabled: !settings.extensionEnabled };
     setSettings(next);
     await saveSettings(next);
+    notifyContentScript(next);
     showToast(next.extensionEnabled ? 'D-Tox enabled' : 'D-Tox paused');
   };
 
@@ -160,6 +172,7 @@ export default function Popup() {
     setCurrentPreset(presetId);
     const s = await loadSettings();
     setSettings(s);
+    notifyContentScript(s);
     showToast(`Applied "${preset.name}"`);
   };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d-tox",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Detox your YouTube. Hide distractions, disable autoplay, and reclaim your attention.",
   "author": "Najmush",
   "license": "MIT",

--- a/src/constants/youtube-elements.ts
+++ b/src/constants/youtube-elements.ts
@@ -203,18 +203,46 @@ export const HIDE_CSS_RULES: Record<string, string> = {
   sidebar: `
     ytd-watch-next-secondary-results-renderer { display: none !important; }
     div#secondary-inner { display: none !important; }
+    #secondary { display: none !important; }
+    #related { display: none !important; }
+    #columns { justify-content: center !important; }
+    #primary { max-width: none !important; }
+    #primary-inner { max-width: none !important; }
+    ytd-watch-flexy[flexy][is-two-columns_] #primary { max-width: none !important; }
   `,
 
   shorts: `
+    /* === Individual Shorts in search/feed — pure CSS, instant === */
+    ytd-video-renderer:has(a#thumbnail[href^="/shorts/"]) { display: none !important; }
+
+    /* === Shorts shelf (horizontal carousel) — YouTube 2025+ === */
+    grid-shelf-view-model:has(ytm-shorts-lockup-view-model) { display: none !important; }
+    grid-shelf-view-model:has(ytm-shorts-lockup-view-model-v2) { display: none !important; }
+    grid-shelf-view-model:has(a[href^="/shorts/"]) { display: none !important; }
+    ytm-shorts-lockup-view-model { display: none !important; }
+    ytm-shorts-lockup-view-model-v2 { display: none !important; }
+
+    /* === Legacy Shorts shelf === */
     ytd-reel-shelf-renderer { display: none !important; }
+    ytd-reel-item-renderer { display: none !important; }
     ytd-rich-section-renderer[is-shorts] { display: none !important; }
     ytd-rich-shelf-renderer[is-shorts] { display: none !important; }
+    ytd-rich-section-renderer:has(ytd-reel-shelf-renderer) { display: none !important; }
+    ytd-rich-section-renderer:has(ytd-rich-shelf-renderer[is-shorts]) { display: none !important; }
+    ytd-item-section-renderer:has(ytd-reel-shelf-renderer) { display: none !important; }
+    ytd-shelf-renderer[is-shorts-shelf] { display: none !important; }
+
+    /* === Shorts chip in search filter bar (JS-marked by text match) === */
+    yt-chip-cloud-chip-renderer[dtox-shorts-chip] { display: none !important; }
+
+    /* === Shorts nav links (sidebar + mini guide) === */
     a[title="Shorts"] { display: none !important; }
     a[href="/shorts"] { display: none !important; }
-    ytd-mini-guide-entry-renderer a[title="Shorts"] { display: none !important; }
-    ytd-guide-entry-renderer a[title="Shorts"] { display: none !important; }
-    [is-shorts] { display: none !important; }
-    ytd-rich-section-renderer:has(ytd-rich-shelf-renderer[is-shorts]) { display: none !important; }
+    ytd-mini-guide-entry-renderer[aria-label="Shorts"] { display: none !important; }
+    ytd-mini-guide-entry-renderer:has(a[title="Shorts"]) { display: none !important; }
+    ytd-mini-guide-entry-renderer:has(a[href="/shorts"]) { display: none !important; }
+    ytd-guide-entry-renderer:has(a[title="Shorts"]) { display: none !important; }
+    ytd-guide-entry-renderer:has(a[href="/shorts"]) { display: none !important; }
   `,
 
   playlists: `
@@ -245,6 +273,7 @@ export const HIDE_CSS_RULES: Record<string, string> = {
   header: `
     #masthead-container { display: none !important; }
     ytd-masthead { display: none !important; }
+    ytd-page-manager { margin-top: 0 !important; }
   `,
 
   notifications: `
@@ -281,7 +310,54 @@ export const HIDE_CSS_RULES: Record<string, string> = {
   `,
 
   explore: `
+    /* === JS-marked explore section (most reliable) === */
+    ytd-guide-section-renderer[dtox-explore-section] { display: none !important; }
+
+    /* === Whole section by content — :has() targets the section containing these links === */
+    ytd-guide-section-renderer:has(a[title="Trending"]) { display: none !important; }
+    ytd-guide-section-renderer:has(a[title="Shopping"]) { display: none !important; }
+    ytd-guide-section-renderer:has(a[title="Gaming"]) { display: none !important; }
+    ytd-guide-section-renderer:has(a[href*="/feed/trending"]) { display: none !important; }
+    ytd-guide-section-renderer:has(a[href*="/feed/explore"]) { display: none !important; }
+
+    /* === Individual entries fallback === */
+    ytd-guide-entry-renderer:has(a[href*="/feed/trending"]) { display: none !important; }
+    ytd-guide-entry-renderer:has(a[href*="/feed/explore"]) { display: none !important; }
+    ytd-mini-guide-entry-renderer:has(a[href*="/feed/trending"]) { display: none !important; }
+    ytd-mini-guide-entry-renderer:has(a[href*="/feed/explore"]) { display: none !important; }
+
+    /* === Direct link targets === */
     a[href*="/feed/explore"] { display: none !important; }
+    a[href*="/feed/trending"] { display: none !important; }
     a[aria-label*="Explore"] { display: none !important; }
+
+    /* === Trending/Explore page content (if user navigates directly) === */
+    ytd-browse[page-subtype="trending"] ytd-rich-grid-renderer { display: none !important; }
+    ytd-browse[page-subtype="trending"] ytd-section-list-renderer { display: none !important; }
+    ytd-browse[page-subtype="explore"] #content { display: none !important; }
+  `,
+
+  searchFilters: `
+    ytd-search-sub-menu-renderer { display: none !important; }
+    ytd-search-filter-group-renderer { display: none !important; }
+    #filter-menu { display: none !important; }
+  `,
+
+  autoplay: `
+    .ytp-ce-element { display: none !important; }
+    .ytp-endscreen-content { display: none !important; }
+    .ytp-autonav-endscreen { display: none !important; }
+    .ytp-ce-covering-overlay { display: none !important; }
+    .ytp-autonav-toggle-button-container { opacity: 0.35 !important; filter: grayscale(1) !important; pointer-events: none !important; }
+  `,
+
+  annotations: `
+    .ytp-ce-element { display: none !important; }
+    .ytp-cards-teaser { display: none !important; }
+    .ytp-ce-expanding-overlay { display: none !important; }
+    .ytp-cards-button { display: none !important; }
+    .ytp-card { display: none !important; }
+    ytp-card-container { display: none !important; }
+    .ytp-ce-covering-overlay { display: none !important; }
   `
 };

--- a/src/utils/css-injector.ts
+++ b/src/utils/css-injector.ts
@@ -32,7 +32,10 @@ function generateHideRules(settings: Settings): string {
     hideScreenCards: 'screenCards',
     hideMerchTicketOffers: 'merchTicketOffers',
     hideVideoInfo: 'videoInfo',
-    hideExplore: 'explore'
+    hideExplore: 'explore',
+    hideSearchResults: 'searchFilters',
+    disableAutoplay: 'autoplay',
+    disableAnnotations: 'annotations'
   };
 
   // Build CSS rules for enabled settings
@@ -47,105 +50,42 @@ function generateHideRules(settings: Settings): string {
 }
 
 /**
- * Generate JavaScript to disable features
- */
-function generateDisableScripts(settings: Settings): string {
-  const scripts: string[] = [];
-
-  // Disable autoplay
-  if (settings.disableAutoplay) {
-    scripts.push(`
-      (function() {
-        // Override autoplay attribute
-        Object.defineProperty(HTMLMediaElement.prototype, 'autoplay', {
-          set: function() {},
-          get: function() { return false; }
-        });
-
-        // Disable autoplay button
-        const observer = new MutationObserver(() => {
-          const autoplayButton = document.querySelector('[aria-label*="Autoplay"]');
-          if (autoplayButton) {
-            autoplayButton.click?.();
-          }
-        });
-
-        observer.observe(document.body, {
-          subtree: true,
-          attributes: true,
-          attributeFilter: ['autoplay']
-        });
-      })();
-    `);
-  }
-
-  // Disable annotations
-  if (settings.disableAnnotations) {
-    scripts.push(`
-      (function() {
-        // Hide interactive cards/annotations
-        const style = document.createElement('style');
-        style.innerHTML = \`
-          ytp-card-container { display: none !important; }
-          .ytp-card { display: none !important; }
-          .ytp-cards-button { display: none !important; }
-        \`;
-        document.head.appendChild(style);
-      })();
-    `);
-  }
-
-  return scripts.join('\n');
-}
-
-/**
- * Inject CSS styles into the page
+ * Inject CSS styles into the page.
+ * Re-uses the existing style tag when possible to avoid triggering
+ * the styleWatchdog MutationObserver unnecessarily.
  */
 export function injectStyles(settings: Settings): void {
-  // Remove existing style tag if present
+  const cssRules = generateHideRules(settings);
   const existingStyle = document.getElementById(STYLE_TAG_ID);
-  if (existingStyle) {
-    existingStyle.remove();
+
+  if (!cssRules) {
+    // No rules needed — remove tag if it exists
+    if (existingStyle) existingStyle.remove();
+    return;
   }
 
-  // Generate CSS rules
-  const cssRules = generateHideRules(settings);
-
-  if (cssRules) {
-    // Create and inject new style tag
+  if (existingStyle) {
+    // Update in-place — no remove/add cycle
+    if (existingStyle.textContent !== cssRules) {
+      existingStyle.textContent = cssRules;
+    }
+  } else {
+    // First injection — create the tag
     const style = document.createElement('style');
     style.id = STYLE_TAG_ID;
     style.type = 'text/css';
-    style.innerHTML = cssRules;
+    style.textContent = cssRules;
     document.head.appendChild(style);
   }
 }
 
 /**
- * Inject disable scripts into the page context
- * Scripts injected this way have access to the page's context
- */
-export function injectDisableScripts(settings: Settings): void {
-  const scripts = generateDisableScripts(settings);
-
-  if (scripts) {
-    const script = document.createElement('script');
-    script.type = 'text/javascript';
-    script.innerHTML = scripts;
-    document.head.appendChild(script);
-  }
-}
-
-/**
- * Apply all styles and scripts based on settings
+ * Apply all styles based on settings.
+ * Autoplay is handled separately via a DOM observer in content.ts
+ * because YouTube's player requires clicking the toggle, not CSS alone.
  */
 export function applyAllRules(settings: Settings): void {
-  // Inject CSS for element hiding
   injectStyles(settings);
-
-  // Inject scripts for feature disabling
-  injectDisableScripts(settings);
-
   console.debug('[D-Tox] Rules applied', settings);
 }
 

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -214,7 +214,7 @@ export const FEATURE_METADATA: FeatureMetadata[] = [
   {
     key: 'disableAnnotations',
     label: 'Disable Annotations',
-    description: 'Hide interactive annotations and cards',
+    description: 'Hides info cards, end screens and clickable overlay links that appear during videos',
     category: 'functionality'
   }
 ];

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   outDir: 'dist',
   manifest: {
     name: 'D-Tox: YouTube Detox',
-    version: '1.2.0',
+    version: '1.3.0',
     description: 'Detox your YouTube. Hide distractions, disable autoplay, and reclaim your attention.',
     permissions: [
       'storage',


### PR DESCRIPTION
## Summary

Closes #5

Complete rebuild of all feature toggles to work instantly, reliably, and performantly on YouTube's current (2025+) DOM.

- **Shorts**: Pure CSS `:has()` selectors replace broken JS marker. Targets new YouTube elements (`grid-shelf-view-model`, `ytm-shorts-lockup-view-model`). Hides Shorts filter chip. Fixes reload loop caused by blanket selectors.
- **Sidebar**: Video auto-centers and expands when sidebar hidden (`max-width: none` override)
- **Header**: Removes 56px gap when hidden (`margin-top: 0` on page manager)
- **Explore**: Targets whole guide section via `:has()` + JS marker
- **Autoplay**: Greys out toggle button visually
- **Instant toggles**: Popup sends `chrome.tabs.sendMessage()` directly + layout reflow forced
- **Performance**: `yt-navigate-finish` event replaces heavy MutationObserver; style tag updated in-place

Bumps version to **1.3.0**.

## Test plan

- [ ] Toggle Shorts ON → Shorts hidden in search results, home feed, nav, filter chips
- [ ] Scroll search results → no Shorts flash, no reload loop
- [ ] Toggle Sidebar ON → sidebar hidden, video expands and centers instantly
- [ ] Toggle Header ON → header hidden, no gap at top
- [ ] Toggle Explore ON → entire Explore section hidden in sidebar
- [ ] Toggle Autoplay ON → autoplay button greyed out
- [ ] Toggle Comments ON → comments hidden instantly
- [ ] Toggle any feature OFF → elements reappear instantly
- [ ] All toggles work without page reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)