### PR TITLE
fix: sidebar layout misalignment, toggle lag, nav reload (v1.4.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to D-Tox will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.0] - 2026-04-28
+
+### Fixed
+- **Sidebar layout misalignment** — text and metadata no longer bleed outside the video width when Sidebar Recommendations is enabled. Root cause was `max-width: none` removing YouTube's own constraint; replaced with `max-width: 1280px; width: 100%` so content stays centered and bounded to the player width (#7)
+- **Toggle performance lag** — removed `void document.body.offsetHeight` forced synchronous reflow that was called on every toggle. Updating a `<style>` tag does not need a manual reflow trigger, making toggles instant and jank-free (#7)
+- **Occasional "needs reload" after navigation** — added a second `apply()` call 600 ms after `yt-navigate-finish` to catch YouTube polymer elements that finish upgrading after the event fires. Eliminates most cases where a toggle appeared to do nothing until reload (#7)
+- **Shorts/Explore toggle needs two clicks** — `startMarkers()` was guarded with `if (!markerInterval)` causing it to keep a stale settings closure when re-toggled. Now always restarts the interval so the latest settings are captured (#7)
+- **Unhandled promise rejection in popup** — `chrome.tabs.sendMessage` was not awaited; added `.catch(() => {})` to silence the "Receiving end does not exist" rejection when the content script hasn't loaded yet
+
+### Changed
+- **Welcome page** — on first install, opens `https://d-tox.najmushsaaquib.com/welcome` instead of the bundled `welcome.html`
+- **Navigation fallback removed** — 1-second `setInterval` URL polling used as nav fallback is removed; `yt-navigate-finish` + the 600 ms delayed re-apply is sufficient and eliminates constant background timer load
+
+---
+
 ## [1.3.0] - 2026-03-31
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -96,8 +96,8 @@ d-tox/
 
 1. **Content script** runs on youtube.com pages
 2. Reads your toggle settings from Chrome Storage
-3. Injects CSS rules to hide selected elements
-4. Uses a MutationObserver to handle YouTube's dynamic content loading
+3. Injects a `<style>` tag with CSS rules to hide selected elements — changes apply instantly without page reload
+4. Listens to YouTube's native `yt-navigate-finish` SPA event to re-apply rules on every navigation
 5. Master toggle can pause all rules instantly
 
 ## Contributing

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -25,7 +25,7 @@ export default defineBackground(() => {
 
       // Open welcome page on first install
       chrome.tabs.create({
-        url: chrome.runtime.getURL('welcome.html'),
+        url: 'https://d-tox.najmushsaaquib.com/welcome',
         active: true
       });
     } else if (details.reason === 'update') {

--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -76,10 +76,10 @@ function clearMarkers() {
 }
 
 function startMarkers(settings: Settings) {
+  // Always restart so the new settings closure replaces the old one
+  stopMarkers();
   markElements(settings);
-  if (!markerInterval) {
-    markerInterval = setInterval(() => markElements(settings), 2000);
-  }
+  markerInterval = setInterval(() => markElements(settings), 2000);
 }
 
 function stopMarkers() {
@@ -103,10 +103,6 @@ export default defineContentScript({
         applyAllRules(settings);
         startMarkers(settings);
 
-        // Force synchronous layout reflow so CSS changes (like sidebar
-        // centering or header removal) apply visually without page reload.
-        void document.body.offsetHeight;
-
         if (settings.disableAutoplay) {
           startAutoplayObserver();
         } else {
@@ -117,7 +113,6 @@ export default defineContentScript({
         stopAutoplayObserver();
         stopMarkers();
         clearMarkers();
-        void document.body.offsetHeight;
       }
     }
 
@@ -139,23 +134,15 @@ export default defineContentScript({
       }
     });
 
-    // Re-apply on YouTube SPA navigation using YouTube's own event
+    // Re-apply on YouTube SPA navigation using YouTube's own event.
+    // The second apply at 600 ms catches YouTube polymer elements that finish
+    // upgrading after yt-navigate-finish fires, eliminating the need to reload.
     document.addEventListener('yt-navigate-finish', () => {
       if (current?.extensionEnabled) {
         apply(current);
+        setTimeout(() => { if (current?.extensionEnabled) apply(current!); }, 600);
       }
     });
-
-    // Fallback: also detect URL changes for edge cases
-    let lastUrl = location.href;
-    const navCheck = setInterval(() => {
-      if (location.href !== lastUrl) {
-        lastUrl = location.href;
-        if (current?.extensionEnabled) {
-          setTimeout(() => apply(current!), 300);
-        }
-      }
-    }, 1000);
 
     // Style tag watchdog — re-inject only if YouTube actually removed it
     const styleWatchdog = new MutationObserver((mutations) => {

--- a/entrypoints/popup/popup.tsx
+++ b/entrypoints/popup/popup.tsx
@@ -142,7 +142,7 @@ export default function Popup() {
     try {
       const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
       if (tab?.id && tab.url?.includes('youtube.com')) {
-        chrome.tabs.sendMessage(tab.id, { type: 'dtox-settings-changed', settings: next });
+        chrome.tabs.sendMessage(tab.id, { type: 'dtox-settings-changed', settings: next }).catch(() => {});
       }
     } catch { /* tab may not have content script yet — storage listener is the fallback */ }
   };

--- a/src/constants/youtube-elements.ts
+++ b/src/constants/youtube-elements.ts
@@ -206,9 +206,9 @@ export const HIDE_CSS_RULES: Record<string, string> = {
     #secondary { display: none !important; }
     #related { display: none !important; }
     #columns { justify-content: center !important; }
-    #primary { max-width: none !important; }
-    #primary-inner { max-width: none !important; }
-    ytd-watch-flexy[flexy][is-two-columns_] #primary { max-width: none !important; }
+    #primary.ytd-watch-flexy { max-width: 1280px !important; width: 100% !important; }
+    #primary-inner { max-width: 1280px !important; }
+    ytd-watch-flexy[flexy][is-two-columns_] #primary { max-width: 1280px !important; }
   `,
 
   shorts: `

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   outDir: 'dist',
   manifest: {
     name: 'D-Tox: YouTube Detox',
-    version: '1.3.0',
+    version: '1.4.0',
     description: 'Detox your YouTube. Hide distractions, disable autoplay, and reclaim your attention.',
     permissions: [
       'storage',


### PR DESCRIPTION
Closes #7

## Summary

- **Sidebar layout fix** — `max-width: none` removed YouTube's own width constraint, causing video metadata to bleed full viewport width past the player edges. Replaced with `max-width: 1280px; width: 100%` so text stays within the video column.
- **Toggle lag eliminated** — removed `void document.body.offsetHeight` forced synchronous reflow called on every toggle; `<style>` tag updates don't need it, making all toggles instant.
- **Nav reload eliminated** — second `apply()` at 600 ms after `yt-navigate-finish` catches YouTube polymer elements that upgrade after the event fires; removed 1 s URL polling `setInterval` (dead background timer).
- **Shorts/Explore stale closure fixed** — `startMarkers()` now always stops+restarts the interval so fresh settings are captured on every toggle.
- **Welcome page** — on first install, opens `https://d-tox.najmushsaaquib.com/welcome` instead of bundled `welcome.html`.
- **Version bumped to 1.4.0**

## Files changed

| File | Change |
|------|--------|
| `src/constants/youtube-elements.ts` | sidebar: `max-width: none` → `max-width: 1280px; width: 100%` |
| `entrypoints/content.ts` | remove forced reflows, remove URL polling, add 600 ms delayed re-apply, fix startMarkers closure |
| `entrypoints/popup/popup.tsx` | `.catch(() => {})` on sendMessage |
| `entrypoints/background.ts` | welcome URL → `https://d-tox.najmushsaaquib.com/welcome` |
| `wxt.config.ts` | version `1.3.0` → `1.4.0` |
| `CHANGELOG.md` | 1.4.0 entry |
| `README.md` | update How It Works step 4 |

## Test plan

- [ ] Open a YouTube watch page, enable Sidebar Recommendations — confirm video and metadata are aligned within player width on both narrow and wide viewports
- [ ] Toggle any feature — confirm no jank or freeze on the YouTube tab
- [ ] Navigate between videos using YouTube SPA — confirm features apply without reload
- [ ] Toggle Shorts off then on — confirm it works in a single click each time
- [ ] Fresh install — confirm browser opens `https://d-tox.najmushsaaquib.com/welcome`

🤖 Generated with [Claude Code](https://claude.com/claude-code)