### PR TITLE
feat: Privacy link in popup footer + homepage_url in manifest (v1.4.1)

### DIFF
--- a/entrypoints/popup/popup.tsx
+++ b/entrypoints/popup/popup.tsx
@@ -15,6 +15,7 @@ const FEATURE_FORM   = 'https://forms.gle/B1eb14KJGTRoiS179';
 const BUG_FORM       = 'https://forms.gle/dLTobfdskRPJ6poY6';
 const GITHUB_URL     = 'https://github.com/najmushsaaquib/d-tox';
 const GITHUB_PROFILE = 'https://github.com/najmushsaaquib';
+const PRIVACY_URL    = 'https://d-tox.najmushsaaquib.com/privacy';
 
 // ── Support Modal ─────────────────────────────────────────────────────────────
 function SupportModal({ onClose, showToast }: { onClose: () => void; showToast: (msg: string) => void }) {
@@ -388,6 +389,8 @@ export default function Popup() {
         <button className="footer-btn" onClick={() => setShowSupport(true)}>🤝 Support</button>
         <span className="footer-dot">·</span>
         <a href={FEATURE_FORM} target="_blank" rel="noopener noreferrer">💡 Request Feature</a>
+        <span className="footer-dot">·</span>
+        <a href={PRIVACY_URL} target="_blank" rel="noopener noreferrer">Privacy</a>
         <span className="footer-dot">·</span>
         <span className="footer-love">Made with ❤️ by <a href={GITHUB_PROFILE} target="_blank" rel="noopener noreferrer" className="author-link">Najmush</a></span>
       </footer>

--- a/promo-tile-440x280.html
+++ b/promo-tile-440x280.html
@@ -1,0 +1,223 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=440, initial-scale=1" />
+  <title>D-Tox — Promo Tile 440×280</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&display=swap" rel="stylesheet" />
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    html, body {
+      width: 440px;
+      height: 280px;
+      overflow: hidden;
+      background: #0a0a0a;
+      font-family: 'Inter', system-ui, sans-serif;
+      -webkit-font-smoothing: antialiased;
+    }
+
+    .tile {
+      width: 440px;
+      height: 280px;
+      background: #0d0d0d;
+      position: relative;
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
+      padding: 28px 32px 26px;
+      overflow: hidden;
+    }
+
+    /* ── Background noise texture ── */
+    .tile::before {
+      content: '';
+      position: absolute;
+      inset: 0;
+      background-image:
+        radial-gradient(ellipse 320px 180px at 85% 110%, rgba(229,62,62,0.10) 0%, transparent 70%),
+        radial-gradient(ellipse 200px 200px at 10% -10%, rgba(96,165,250,0.06) 0%, transparent 60%);
+      pointer-events: none;
+    }
+
+    /* ── Subtle grid lines ── */
+    .tile::after {
+      content: '';
+      position: absolute;
+      inset: 0;
+      background-image:
+        linear-gradient(rgba(255,255,255,0.025) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(255,255,255,0.025) 1px, transparent 1px);
+      background-size: 40px 40px;
+      pointer-events: none;
+    }
+
+    /* ── Top row: logo + badge ── */
+    .top-row {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      position: relative;
+      z-index: 1;
+    }
+
+    .logo-group {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+    }
+
+    .logo-icon {
+      width: 32px;
+      height: 32px;
+      flex-shrink: 0;
+    }
+
+    .logo-name {
+      font-size: 20px;
+      font-weight: 800;
+      color: #f5f5f5;
+      letter-spacing: -0.3px;
+    }
+
+    .badge {
+      font-size: 10px;
+      font-weight: 600;
+      color: #999;
+      background: rgba(255,255,255,0.06);
+      border: 1px solid rgba(255,255,255,0.08);
+      border-radius: 20px;
+      padding: 4px 10px;
+      letter-spacing: 0.3px;
+      text-transform: uppercase;
+    }
+
+    /* ── Centre: headline ── */
+    .headline {
+      position: relative;
+      z-index: 1;
+    }
+
+    .headline h2 {
+      font-size: 34px;
+      font-weight: 900;
+      line-height: 1.08;
+      letter-spacing: -1px;
+      color: #f0f0f0;
+    }
+
+    .headline h2 em {
+      font-style: normal;
+      color: #e53e3e;
+    }
+
+    .headline p {
+      margin-top: 8px;
+      font-size: 13px;
+      font-weight: 400;
+      color: #777;
+      line-height: 1.4;
+      letter-spacing: 0.1px;
+    }
+
+    /* ── Bottom row: toggles pill strip ── */
+    .bottom-row {
+      display: flex;
+      align-items: center;
+      gap: 5px;
+      position: relative;
+      z-index: 1;
+      flex-wrap: nowrap;
+    }
+
+    .tag {
+      display: flex;
+      align-items: center;
+      gap: 4px;
+      font-size: 10px;
+      font-weight: 500;
+      color: #bbb;
+      background: rgba(255,255,255,0.055);
+      border: 1px solid rgba(255,255,255,0.07);
+      border-radius: 20px;
+      padding: 4px 9px 4px 7px;
+      white-space: nowrap;
+    }
+
+    .tag-dot {
+      width: 6px;
+      height: 6px;
+      border-radius: 50%;
+      background: #e53e3e;
+      flex-shrink: 0;
+    }
+
+    .tag-dot.blue { background: #60a5fa; }
+    .tag-dot.green { background: #34d399; }
+    .tag-dot.yellow { background: #fbbf24; }
+    .tag-dot.purple { background: #a78bfa; }
+
+    .divider {
+      color: rgba(255,255,255,0.12);
+      font-size: 11px;
+      user-select: none;
+    }
+
+    /* ── Decorative vertical red line ── */
+    .accent-line {
+      position: absolute;
+      right: 32px;
+      top: 50%;
+      transform: translateY(-50%);
+      width: 3px;
+      height: 72px;
+      background: linear-gradient(to bottom, transparent, #e53e3e 40%, #e53e3e 60%, transparent);
+      border-radius: 2px;
+      z-index: 1;
+      opacity: 0.7;
+    }
+  </style>
+</head>
+<body>
+  <div class="tile">
+
+    <!-- decorative accent -->
+    <div class="accent-line"></div>
+
+    <!-- Top: logo + badge -->
+    <div class="top-row">
+      <div class="logo-group">
+        <svg class="logo-icon" viewBox="0 0 128 128" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <clipPath id="lc">
+            <path d="M36,26 L36,102 C36,104 38,105 41,103 L102,69 C105,67 105,61 102,59 L41,25 C38,23 36,24 36,26 Z"/>
+          </clipPath>
+          <g clip-path="url(#lc)">
+            <rect x="0" y="0" width="128" height="128" fill="#e53e3e"/>
+            <circle cx="102" cy="64" r="26" fill="#60a5fa"/>
+          </g>
+        </svg>
+        <span class="logo-name">D-Tox</span>
+      </div>
+      <span class="badge">Free &amp; Open Source</span>
+    </div>
+
+    <!-- Centre: headline -->
+    <div class="headline">
+      <h2>Take back<br/><em>your</em> YouTube.</h2>
+      <p>Hide Shorts, kill autoplay, block the feed.<br/>20 toggles. Zero distractions.</p>
+    </div>
+
+    <!-- Bottom: feature tags -->
+    <div class="bottom-row">
+      <div class="tag"><span class="tag-dot"></span>No Shorts</div>
+      <div class="tag"><span class="tag-dot blue"></span>No Autoplay</div>
+      <div class="tag"><span class="tag-dot green"></span>No Feed</div>
+      <div class="tag"><span class="tag-dot yellow"></span>No Sidebar</div>
+      <div class="tag"><span class="tag-dot purple"></span>No Noise</div>
+    </div>
+
+  </div>
+</body>
+</html>

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -6,8 +6,9 @@ export default defineConfig({
   outDir: 'dist',
   manifest: {
     name: 'D-Tox: YouTube Detox',
-    version: '1.4.0',
+    version: '1.4.1',
     description: 'Detox your YouTube. Hide distractions, disable autoplay, and reclaim your attention.',
+    homepage_url: 'https://d-tox.najmushsaaquib.com',
     permissions: [
       'storage',
       'activeTab',


### PR DESCRIPTION
Closes #9

## Summary

- **Popup footer**: added `Privacy` link pointing to `https://d-tox.najmushsaaquib.com/privacy` — visible on every popup open alongside Support and Request Feature
- **Manifest**: added `homepage_url: 'https://d-tox.najmushsaaquib.com'` — shows up on the CWS listing and in `chrome://extensions`
- **Version**: `1.4.0` → `1.4.1`
- **Promo tile**: `promo-tile-440x280.html` — ready-to-screenshot 440×280 CWS small promotional tile

## After merging

1. Build + zip: `npm run build && zip -r D-Tox-v1.4.1-chrome.zip dist/chrome-mv3/`
2. Upload to CWS developer console
3. In CWS dashboard → **Store listing** → update **Privacy policy URL** to `https://d-tox.najmushsaaquib.com/privacy`
4. Upload `promo-tile-440x280.html` screenshot (440×280) to **Graphic assets → Small promo tile**

🤖 Generated with [Claude Code](https://claude.com/claude-code)